### PR TITLE
changed to use system VTK paths

### DIFF
--- a/pointcloud_tools/CMakeLists.txt
+++ b/pointcloud_tools/CMakeLists.txt
@@ -3,13 +3,14 @@ project(pointcloud_tools)
 
 find_package(catkin REQUIRED COMPONENTS roscpp pcl_ros std_msgs sensor_msgs nav_msgs)
 find_package(PCL REQUIRED)
+find_package(VTK REQUIRED)
 
 find_package(Boost REQUIRED COMPONENTS signals filesystem system)
 include_directories(${Boost_INCLUDE_DIRS})
 
 catkin_package()
 
-include_directories(/usr/include/vtk-5.8 ${catkin_INCLUDE_DIRS} ${PCL_INCLUDE_DIRS})
+include_directories(${catkin_INCLUDE_DIRS} ${PCL_INCLUDE_DIRS} ${VTK_INCLUDE_DIRS})
 
 add_executable(pointcloud_mapper src/pointcloud_mapper.cpp)
 add_executable(pointcloud_mapper_for_slam src/pointcloud_mapper_for_slam.cpp)
@@ -18,7 +19,7 @@ add_executable(pcd_publisher src/pcd_publisher.cpp)
 add_executable(pointcloud_viewer src/pointcloud_viewer.cpp)
 add_executable(pointcloud_to_webgl src/pointcloud_to_webgl.cpp)
 
-target_link_libraries(pointcloud_viewer ${Boost_LIBRARIES} ${PCL_LIBRARIES} ${catkin_LIBRARIES} libvtkCommon.so libvtkFiltering.so libvtkRendering.so)
+target_link_libraries(pointcloud_viewer ${Boost_LIBRARIES} ${PCL_LIBRARIES} ${catkin_LIBRARIES} ${VTK_LIBRARIES})
 target_link_libraries(pcd_publisher ${PCL_LIBRARIES} ${catkin_LIBRARIES})
 target_link_libraries(pointcloud_mapper ${PCL_LIBRARIES} ${catkin_LIBRARIES})
 target_link_libraries(pointcloud_mapper_for_slam ${PCL_LIBRARIES} ${catkin_LIBRARIES})

--- a/pointcloud_tools/package.xml
+++ b/pointcloud_tools/package.xml
@@ -17,11 +17,13 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
+  <build_depend>libvtk</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>
+  <run_depend>libvtk</run_depend>
 
   <export>
 


### PR DESCRIPTION
Neither the VTK include paths or the VTK libraries listed currently are valid on Fedora.

If you use CMake to detect these values, they'll be right on any system with valid VTK.

Example build break: http://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-pointcloud-tools_binaryrpm_heisenbug_x86_64/2/console

Thanks,

--scott
