### PR TITLE
Fix rosdep key

### DIFF
--- a/launch_tools/package.xml
+++ b/launch_tools/package.xml
@@ -15,7 +15,7 @@
   <build_depend>rospy</build_depend>
   <build_depend>roslib</build_depend>
   <run_depend>rospy</run_depend>
-  <run_depend>xdot</run_depend>
+  <run_depend>python-xdot</run_depend>
   <run_depend>roslib</run_depend>
 
 </package>


### PR DESCRIPTION
xdot key was renamed, as explained in https://github.com/srv/srv_tools/issues/16 using the new name

Some extra discussion can be found here: https://github.com/ros/rosdistro/pull/17553#pullrequestreview-114509432