### PR TITLE
Fix start time.

### DIFF
--- a/bag_tools/scripts/cut.py
+++ b/bag_tools/scripts/cut.py
@@ -39,7 +39,7 @@ import sys
 import argparse
 
 def cut(inbags, outbagfile, start, duration):
-  start_time = rospy.Time.from_sec(999999999999)
+  start_time = rospy.Time.from_sec(0)
   for inbag in inbags:
     rospy.loginfo('   Looking for smallest time in: %s', inbag)
     for topic, msg, t in rosbag.Bag(inbag,'r').read_messages():


### PR DESCRIPTION
```rosrun bag_tools cut.py``` was not working for me. It did not find a valid interval to cut. I'm not sure why the start time was set to this number. Setting it to zero seems to do the job.