### PR TITLE
Fix for bag_add_time_offset crash

### DIFF
--- a/bag_tools/scripts/bag_add_time_offset.py
+++ b/bag_tools/scripts/bag_add_time_offset.py
@@ -75,7 +75,8 @@ if __name__ == "__main__":
   parser.add_argument('-t', metavar='TOPIC', required=True, help='topic(s) to change', nargs='+')
   args = parser.parse_args()
   try:
-      fix_bagfile(args.i, args.o, arg.t, args.of)
+    for bagfile in args.i:
+      fix_bagfile(bagfile, args.o, args.t, args.of)
   except Exception, e:
       import traceback
       traceback.print_exc()


### PR DESCRIPTION
Fix #25 

Fix incorrect 'arg.t' reference.

Input bag file argument is an array, iterate through each input bag file instead.